### PR TITLE
Add matplotlib to required python packages

### DIFF
--- a/python-package-requirement.txt
+++ b/python-package-requirement.txt
@@ -5,3 +5,4 @@ requests
 numpy
 scipy
 bs4
+matplotlib


### PR DESCRIPTION
The GeneTaggerExample needs this package.