### PR TITLE
Require Theano >= 0.8.2

### DIFF
--- a/python-package-requirement.txt
+++ b/python-package-requirement.txt
@@ -6,4 +6,4 @@ numpy
 scipy
 bs4
 matplotlib
-theano
+theano>=0.8.2


### PR DESCRIPTION
Testing one of the notebooks, it breaks with Theano 0.7, so should require a recent build.